### PR TITLE
Allow other framework environment to check as well

### DIFF
--- a/lib/config_reader.rb
+++ b/lib/config_reader.rb
@@ -25,31 +25,32 @@ class ConfigReader
     def reload
       raise 'No config file set' unless @config_file
 
-      if defined?(ERB)
-        conf = YAML.load(ERB.new(File.open(find_config).read).result)
+      conf = if defined?(ERB)
+        YAML.load(ERB.new(File.open(find_config).read).result)
       else
-        conf = YAML.load(File.open(find_config).read)
+        YAML.load(File.open(find_config).read)
       end
 
       raise 'No config found' unless conf
+      ## because Padrino.env return a symbol
+      _conf = ConfigReader::MagicHash.convert_hash(conf)
 
-      if defined?(Rails) and Rails.env
-        env = Rails.env
+      env = if defined?(Rails) and Rails.env
+        Rails.env
       elsif defined?(RAILS_ENV)
-        env = RAILS_ENV
+        RAILS_ENV
       elsif defined?(Padrino) and Padrino.env
-        env = Padrino.env
+        Padrino.env
       elsif defined?(PADRINO_ENV)
-        env = PADRINO_ENV
+        PADRINO_ENV
       elsif ENV['RACK_ENV']
-        env = ENV['RACK_ENV']
+        ENV['RACK_ENV']
       elsif defined?(APP_ENV)
-        env = APP_ENV
+        APP_ENV
       end
 
-      _conf = conf['defaults']
-      _conf.merge!(conf[env]) if conf[env]
-      ConfigReader::MagicHash.convert_hash(_conf)
+      _default_conf = _conf['defaults'] || {}
+      _default_conf.merge(_conf[env] || {})
     end
 
     def [](key)

--- a/lib/config_reader.rb
+++ b/lib/config_reader.rb
@@ -33,10 +33,16 @@ class ConfigReader
 
       raise 'No config found' unless conf
 
-      if defined?(Rails) && Rails.env
+      if defined?(Rails) and Rails.env
         env = Rails.env
       elsif defined?(RAILS_ENV)
         env = RAILS_ENV
+      elsif defined?(Padrino) and Padrino.env
+        env = Padrino.env
+      elsif defined?(PADRINO_ENV)
+        env = PADRINO_ENV
+      elsif ENV['RACK_ENV']
+        env = ENV['RACK_ENV']
       elsif defined?(APP_ENV)
         env = APP_ENV
       end

--- a/lib/config_reader/magic_hash.rb
+++ b/lib/config_reader/magic_hash.rb
@@ -19,7 +19,7 @@ class ConfigReader
       super(key.to_sym)
     end
     
-    ## Let everything key added in future  be a symbol
+    ## Let every key added in future  be a symbol
     def []=(key,value)
       super(key.to_sym,value)
     end  

--- a/lib/config_reader/magic_hash.rb
+++ b/lib/config_reader/magic_hash.rb
@@ -11,17 +11,21 @@ class ConfigReader
           magic_hash[key.to_sym] = value
         end
       end
-
       magic_hash
     end
 
+    ## Dont throw any error 
     def [](key)
-      fetch(key.to_sym)
+      super(key.to_sym)
     end
+    
+    ## Let everything key added in future  be a symbol
+    def []=(key,value)
+      super(key.to_sym,value)
+    end  
 
     def method_missing(key)
       has_key?(key) ? fetch(key) : super
     end
-
   end
 end

--- a/lib/config_reader/magic_hash.rb
+++ b/lib/config_reader/magic_hash.rb
@@ -20,9 +20,7 @@ class ConfigReader
     end
 
     def method_missing(key)
-      has_key?(key) ?
-        fetch(key) :
-        super
+      has_key?(key) ? fetch(key) : super
     end
 
   end


### PR DESCRIPTION
Allow Check for framework like **Padrino** and other Rack framework with **RACK['ENV']** 

Also noted that if the environment variable(`env` ) happen to be symbol the app just doesn't load the desired configuration . 

The Following Commit contain a fix for that as well 
