### PR TITLE
Bump version to 3.0.4, update changelog, and fix reload method to pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.4 2024-06-10
+
+Make reload actually reload, useful in development.
+
 ## 3.0.3 2025-01-06
 
 Fix a bug in deep merge where values weren't getting set properly.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    config_reader (3.0.3)
+    config_reader (3.0.4)
       abbrev
       psych (~> 5.2, >= 5.2.1)
 
@@ -23,6 +23,7 @@ GEM
       thor
       tilt
     highline (1.7.10)
+    io-console (0.8.2)
     json (2.13.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -45,19 +46,22 @@ GEM
       syntax_tree-rbs (>= 0.2.0)
     prettier_print (1.2.1)
     prism (1.4.0)
-    pry (0.15.2)
+    pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+      reline (>= 0.6.0)
     psych (5.2.6)
       date
       stringio
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.3.1)
     rbs (3.9.4)
       logger
     regexp_parser (2.11.0)
-    rspec (3.13.1)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)

--- a/lib/config_reader.rb
+++ b/lib/config_reader.rb
@@ -141,7 +141,7 @@ class ConfigReader
     end
 
     def reload
-      merge_configs(load_config, load_sekrets)
+      @config = merge_configs(load_config, load_sekrets)
     end
 
     def respond_to_missing?(m, *)

--- a/lib/config_reader/version.rb
+++ b/lib/config_reader/version.rb
@@ -1,3 +1,3 @@
 class ConfigReader
-  VERSION = "3.0.3"
+  VERSION = "3.0.4"
 end


### PR DESCRIPTION
This pull request updates the `ConfigReader` gem to version 3.0.4 and fixes the `reload` method so that it properly reloads configuration data, which is especially useful during development.

Version bump and documentation:

* Updated `lib/config_reader/version.rb` to set the version to `3.0.4`.
* Added a changelog entry for version 3.0.4 in `CHANGELOG.md`, noting the reload improvement.

Bug fix:

* Modified the `reload` method in `lib/config_reader.rb` to actually update the internal config state, ensuring that calling `reload` refreshes the configuration as expected.